### PR TITLE
using jsDelivr CDN instead of Google's

### DIFF
--- a/assets/modelviewer-template.html
+++ b/assets/modelviewer-template.html
@@ -3,7 +3,7 @@
 
 <head>
     <!-- Import the component -->
-    <script src="https://ajax.googleapis.com/ajax/libs/model-viewer/3.1.1/model-viewer.min.js" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@google/model-viewer@3.1.1/dist/model-viewer.min.js" type="module"></script>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/assets/modelviewer-textured-template.html
+++ b/assets/modelviewer-textured-template.html
@@ -3,7 +3,7 @@
 
 <head>
     <!-- Import the component -->
-    <script src="https://ajax.googleapis.com/ajax/libs/model-viewer/3.1.1/model-viewer.min.js" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@google/model-viewer@3.1.1/dist/model-viewer.min.js" type="module"></script>
 
     <style>
         body {


### PR DESCRIPTION
https://ajax.googleapis.com is blocked in some places, but https://cdn.jsdelivr.net is mostly accessible.

And this CDN is documented in [Google's repo](https://github.com/google/model-viewer/tree/master/packages/model-viewer#cdn). I believe it's safe to swap.