### PR TITLE
Add Windows setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ cd hy3dgen/texgen/custom_rasterizer
 python3 setup.py install
 cd ../../..
 cd hy3dgen/texgen/differentiable_renderer
-bash compile_mesh_painter.sh
+bash compile_mesh_painter.sh OR python3 setup.py install (on Windows)
 ```
 
 ### API Usage

--- a/README_ja_jp.md
+++ b/README_ja_jp.md
@@ -105,7 +105,7 @@ pip install -r requirements.txt
 cd hy3dgen/texgen/custom_rasterizer
 python3 setup.py install
 cd hy3dgen/texgen/differentiable_renderer
-bash compile_mesh_painter.sh
+bash compile_mesh_painter.sh OR python3 setup.py install (on Windows)
 ```
 
 ### APIの使い方

--- a/hy3dgen/texgen/differentiable_renderer/setup.py
+++ b/hy3dgen/texgen/differentiable_renderer/setup.py
@@ -1,0 +1,47 @@
+from setuptools import setup, Extension
+import pybind11
+import sys
+import platform
+
+# Common compile arguments
+common_compile_args = []
+
+if sys.platform == 'win32':
+    # Windows-specific compile arguments
+    extra_compile_args = [
+        '/O2',  # Optimization level
+        '/std:c++14',  # C++ standard (using C++14 for better compatibility)
+        '/EHsc',  # Exception handling model
+        '/MP',  # Multi-process compilation
+        '/DWIN32_LEAN_AND_MEAN',  # Exclude rarely-used Windows headers
+    ]
+    extra_link_args = []
+else:
+    # Linux/Unix compile arguments
+    extra_compile_args = [
+        '-O3',  # Optimization level
+        '-std=c++14',  # C++ standard
+        '-fPIC',  # Position independent code
+    ]
+    extra_link_args = ['-fPIC']
+
+ext_modules = [
+    Extension(
+        "mesh_processor",
+        ["mesh_processor.cpp"],
+        include_dirs=[
+            pybind11.get_include(),
+            pybind11.get_include(user=True)
+        ],
+        language='c++',
+        extra_compile_args=common_compile_args + extra_compile_args,
+        extra_link_args=extra_link_args,
+    ),
+]
+
+setup(
+    name="mesh_processor",
+    ext_modules=ext_modules,
+    install_requires=['pybind11>=2.6.0'],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
Compiling differentiable_renderer on Windows requires following command:
bash compile_mesh_painter.sh
But if WSL is not used - simple setup.py can be used for the same purpose - which is added by this PR.