### PR TITLE
Updating the setup.py script to be more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cd hy3dgen/texgen/custom_rasterizer
 python3 setup.py install
 cd ../../..
 cd hy3dgen/texgen/differentiable_renderer
-bash compile_mesh_painter.sh OR python3 setup.py install (on Windows)
+python3 setup.py install
 ```
 
 ### API Usage

--- a/README_ja_jp.md
+++ b/README_ja_jp.md
@@ -105,7 +105,7 @@ pip install -r requirements.txt
 cd hy3dgen/texgen/custom_rasterizer
 python3 setup.py install
 cd hy3dgen/texgen/differentiable_renderer
-bash compile_mesh_painter.sh OR python3 setup.py install (on Windows)
+python3 setup.py install
 ```
 
 ### APIの使い方

--- a/hy3dgen/texgen/differentiable_renderer/compile_mesh_painter.sh
+++ b/hy3dgen/texgen/differentiable_renderer/compile_mesh_painter.sh
@@ -1,1 +1,0 @@
-c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` mesh_processor.cpp -o mesh_processor`python3-config --extension-suffix`

--- a/hy3dgen/texgen/differentiable_renderer/setup.py
+++ b/hy3dgen/texgen/differentiable_renderer/setup.py
@@ -3,38 +3,39 @@ import pybind11
 import sys
 import platform
 
-# Common compile arguments
-common_compile_args = []
+def get_platform_specific_args():
+    system = platform.system().lower()
+    cpp_std = 'c++14'  # Make configurable if needed
+    
+    if sys.platform == 'win32':
+        compile_args = ['/O2', f'/std:{cpp_std}', '/EHsc', '/MP', '/DWIN32_LEAN_AND_MEAN', '/bigobj']
+        link_args = []
+        extra_includes = []
+    elif system == 'linux':
+        compile_args = ['-O3', f'-std={cpp_std}', '-fPIC', '-Wall', '-Wextra', '-pthread']
+        link_args = ['-fPIC', '-pthread']
+        extra_includes = []
+    elif sys.platform == 'darwin':
+        compile_args = ['-O3', f'-std={cpp_std}', '-fPIC', '-Wall', '-Wextra',
+                       '-stdlib=libc++', '-mmacosx-version-min=10.14']
+        link_args = ['-fPIC', '-stdlib=libc++', '-mmacosx-version-min=10.14', '-dynamiclib']
+        extra_includes = []
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}")
+    
+    return compile_args, link_args, extra_includes
 
-if sys.platform == 'win32':
-    # Windows-specific compile arguments
-    extra_compile_args = [
-        '/O2',  # Optimization level
-        '/std:c++14',  # C++ standard (using C++14 for better compatibility)
-        '/EHsc',  # Exception handling model
-        '/MP',  # Multi-process compilation
-        '/DWIN32_LEAN_AND_MEAN',  # Exclude rarely-used Windows headers
-    ]
-    extra_link_args = []
-else:
-    # Linux/Unix compile arguments
-    extra_compile_args = [
-        '-O3',  # Optimization level
-        '-std=c++14',  # C++ standard
-        '-fPIC',  # Position independent code
-    ]
-    extra_link_args = ['-fPIC']
+extra_compile_args, extra_link_args, platform_includes = get_platform_specific_args()
+include_dirs = [pybind11.get_include(), pybind11.get_include(user=True)]
+include_dirs.extend(platform_includes)
 
 ext_modules = [
     Extension(
         "mesh_processor",
         ["mesh_processor.cpp"],
-        include_dirs=[
-            pybind11.get_include(),
-            pybind11.get_include(user=True)
-        ],
+        include_dirs=include_dirs,
         language='c++',
-        extra_compile_args=common_compile_args + extra_compile_args,
+        extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     ),
 ]


### PR DESCRIPTION
The setup.py has been updated for more flexibility - since it supports Win/Linux/Mac now - the shell build script can be removed.
The readme files were also updated - simplified.