### PR TITLE
fix: texgen should be optional

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -354,11 +354,6 @@ if __name__ == '__main__':
     example_is = get_example_img_list()
     example_ts = get_example_txt_list()
 
-    from hy3dgen.texgen import Hunyuan3DPaintPipeline
-
-    texgen_worker = Hunyuan3DPaintPipeline.from_pretrained('tencent/Hunyuan3D-2')
-    HAS_TEXTUREGEN = True
-
     try:
         from hy3dgen.texgen import Hunyuan3DPaintPipeline
 


### PR DESCRIPTION
This is a bug introduced in #13. I believe it's intended for debugging. But now this code block should be removed so the Gradio App can run without Texture Generation feature.