### PR TITLE
Fix tempfile handling in ModelWorker and change port argument

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -186,9 +186,11 @@ class ModelWorker:
             mesh = FaceReducer()(mesh, max_facenum=params.get('face_count', 40000))
             mesh = self.pipeline_tex(mesh, image)
 
-        with tempfile.NamedTemporaryFile(suffix='.glb', delete=True) as temp_file:
+        with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as temp_file:
             mesh.export(temp_file.name)
             mesh = trimesh.load(temp_file.name)
+            temp_file.close()
+            os.unlink(temp_file.name)
             save_path = os.path.join(SAVE_DIR, f'{str(uid)}.glb')
             mesh.export(save_path)
 
@@ -258,7 +260,7 @@ async def status(uid: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
-    parser.add_argument("--port", type=str, default="8081")
+    parser.add_argument("--port", type=int, default=8081)
     parser.add_argument("--model_path", type=str, default='tencent/Hunyuan3D-2')
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--limit-model-concurrency", type=int, default=5)


### PR DESCRIPTION
This pull request includes changes to the `api_server.py` file to fix a temporary file handling issue and correct the data type for a command-line argument.

File handling improvement:

* [`api_server.py`](diffhunk://#diff-6494ba5ca46ea83ed48fce023cab182e48b0cec420c2131381620358f126643fL189-R193): Modified the `generate` method to ensure temporary files are properly closed and deleted after use. This change prevents potential issues with file locks or leftover temporary files.

Command-line argument correction:

* [`api_server.py`](diffhunk://#diff-6494ba5ca46ea83ed48fce023cab182e48b0cec420c2131381620358f126643fL261-R263): Changed the data type of the `--port` argument from `str` to `int` to ensure the port number is correctly parsed and used.