### PR TITLE
change seed from 1e7 to 10000000

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -29,7 +29,7 @@ import uuid
 
 from hy3dgen.shapegen.utils import logger
 
-MAX_SEED = 1e7
+MAX_SEED = 10000000
 
 
 def get_example_img_list():


### PR DESCRIPTION
I was using Python 3.12. but got an error 'TypeError: 'float' object cannot be interpreted as an integer". Seems the 1e7 caused the issue. changed it to int number. 