### PR TITLE
mps support

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -714,7 +714,7 @@ if __name__ == '__main__':
     if args.enable_t23d:
         from hy3dgen.text2image import HunyuanDiTPipeline
 
-        t2i_worker = HunyuanDiTPipeline('Tencent-Hunyuan/HunyuanDiT-v1.1-Diffusers-Distilled')
+        t2i_worker = HunyuanDiTPipeline('Tencent-Hunyuan/HunyuanDiT-v1.1-Diffusers-Distilled', device=args.device)
         HAS_T2I = True
 
     from hy3dgen.shapegen import FaceReducer, FloaterRemover, DegenerateFaceRemover, MeshSimplifier, \


### PR DESCRIPTION
if the `device` is not passed, the `hy3dgen.text2image` constructor will automatically assume the default device `cuda`.

I can confirm that everything works fine after changing this line and launching with the `--device mps` flag as suggested in https://github.com/Tencent/Hunyuan3D-2/issues/151#issuecomment-2745198170 -- also, didn't need to send the device to float32 (I assume this is only for older devices)