### PR TITLE
Make port number a numeric command line argument

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -300,7 +300,7 @@ async def status(uid: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
-    parser.add_argument("--port", type=str, default="8081")
+    parser.add_argument("--port", type=int, default=8081)
     parser.add_argument("--model_path", type=str, default='tencent/Hunyuan3D-2mini')
     parser.add_argument("--tex_model_path", type=str, default='tencent/Hunyuan3D-2')
     parser.add_argument("--device", type=str, default="cuda")


### PR DESCRIPTION
If treated as a string, it causes an error when attempting to log via uvicorn.

This is a nicer way to resolve this issue: https://github.com/Tencent/Hunyuan3D-2/issues/160