### PR TITLE
Fix unreachable rembg code in examples

### DIFF
--- a/examples/fast_shape_gen_multiview.py
+++ b/examples/fast_shape_gen_multiview.py
@@ -13,7 +13,9 @@ images = {
 }
 
 for key in images:
-    image = Image.open(images[key]).convert("RGBA")
+    image = Image.open(images[key])
+    if image.mode not in ['RGB', 'RGBA']:
+        image = image.convert('RGB')
     if image.mode == 'RGB':
         rembg = BackgroundRemover()
         image = rembg(image)

--- a/examples/fast_shape_gen_with_flashvdm.py
+++ b/examples/fast_shape_gen_with_flashvdm.py
@@ -19,7 +19,9 @@ pipeline.enable_flashvdm()
 # pipeline.compile()
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/faster_shape_gen_with_flashvdm_mini_turbo.py
+++ b/examples/faster_shape_gen_with_flashvdm_mini_turbo.py
@@ -21,7 +21,9 @@ pipeline.enable_flashvdm(topk_mode='merge')
 # pipeline.compile()
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/shape_gen.py
+++ b/examples/shape_gen.py
@@ -7,7 +7,9 @@ from hy3dgen.rembg import BackgroundRemover
 from hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/shape_gen_mini.py
+++ b/examples/shape_gen_mini.py
@@ -7,7 +7,9 @@ from hy3dgen.rembg import BackgroundRemover
 from hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/shape_gen_multiview.py
+++ b/examples/shape_gen_multiview.py
@@ -13,7 +13,9 @@ images = {
 }
 
 for key in images:
-    image = Image.open(images[key]).convert("RGBA")
+    image = Image.open(images[key])
+    if image.mode not in ['RGB', 'RGBA']:
+        image = image.convert('RGB')
     if image.mode == 'RGB':
         rembg = BackgroundRemover()
         image = rembg(image)

--- a/examples/textured_shape_gen.py
+++ b/examples/textured_shape_gen.py
@@ -9,7 +9,9 @@ pipeline_shapegen = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(model_path)
 pipeline_texgen = Hunyuan3DPaintPipeline.from_pretrained(model_path)
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/textured_shape_gen_mini.py
+++ b/examples/textured_shape_gen_mini.py
@@ -8,7 +8,9 @@ from hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline
 from hy3dgen.texgen import Hunyuan3DPaintPipeline
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)

--- a/examples/textured_shape_gen_multiview.py
+++ b/examples/textured_shape_gen_multiview.py
@@ -14,7 +14,9 @@ images = {
 }
 
 for key in images:
-    image = Image.open(images[key]).convert("RGBA")
+    image = Image.open(images[key])
+    if image.mode not in ['RGB', 'RGBA']:
+        image = image.convert('RGB')
     if image.mode == 'RGB':
         rembg = BackgroundRemover()
         image = rembg(image)

--- a/minimal_demo.py
+++ b/minimal_demo.py
@@ -23,7 +23,9 @@ pipeline_shapegen = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(model_path)
 pipeline_texgen = Hunyuan3DPaintPipeline.from_pretrained(model_path)
 
 image_path = 'assets/demo.png'
-image = Image.open(image_path).convert("RGBA")
+image = Image.open(image_path)
+if image.mode not in ['RGB', 'RGBA']:
+    image = image.convert('RGB')
 if image.mode == 'RGB':
     rembg = BackgroundRemover()
     image = rembg(image)


### PR DESCRIPTION
If the image is always converted to `'RGBA'` then the subsequent check `if image.mode == 'RGB'` will never trigger and thus `rembg` will never be executed.