### PR TITLE
Add subfolder argument to api_server,py

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -302,6 +302,7 @@ if __name__ == "__main__":
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8081)
     parser.add_argument("--model_path", type=str, default='tencent/Hunyuan3D-2mini')
+    parser.add_argument("--subfolder", type=str, default='hunyuan3d-dit-v2-mini-turbo')
     parser.add_argument("--tex_model_path", type=str, default='tencent/Hunyuan3D-2')
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--limit-model-concurrency", type=int, default=5)
@@ -311,6 +312,6 @@ if __name__ == "__main__":
 
     model_semaphore = asyncio.Semaphore(args.limit_model_concurrency)
 
-    worker = ModelWorker(model_path=args.model_path, device=args.device, enable_tex=args.enable_tex,
+    worker = ModelWorker(model_path=args.model_path, subfolder=args.subfolder, device=args.device, enable_tex=args.enable_tex,
                          tex_model_path=args.tex_model_path)
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
api_server.py currently does not support selecting a model.  
This PR adds a new command-line option (`--subfolder`) that allows you to specify the model subfolder to use.
