### PR TITLE
Fix Load Local Model Logic

### DIFF
--- a/hy3dgen/texgen/pipelines.py
+++ b/hy3dgen/texgen/pipelines.py
@@ -54,7 +54,7 @@ class Hunyuan3DPaintPipeline:
     @classmethod
     def from_pretrained(cls, model_path, subfolder='hunyuan3d-paint-v2-0-turbo'):
         original_model_path = model_path
-        if not os.path.exists(model_path):
+        if os.path.exists(model_path):
             # try local path
             base_dir = os.environ.get('HY3DGEN_MODELS', '~/.cache/hy3dgen')
             model_path = os.path.expanduser(os.path.join(base_dir, model_path))


### PR DESCRIPTION
fix conditional logic when models have been downloaded in line 57 of file [texgen/pipelines.py](https://github.com/Tencent-Hunyuan/Hunyuan3D-2/blob/main/hy3dgen/texgen/pipelines.py)

from
```
if not os.path.exists(model_path):
            # try local path
            base_dir = os.environ.get('HY3DGEN_MODELS', '~/.cache/hy3dgen')
```

to
```
if os.path.exists(model_path):
            # try local path
            base_dir = os.environ.get('HY3DGEN_MODELS', '~/.cache/hy3dgen')
```