### PR TITLE
Update model loading to support local checkpoints

### DIFF
--- a/minimal_demo.py
+++ b/minimal_demo.py
@@ -18,7 +18,7 @@ from hy3dgen.rembg import BackgroundRemover
 from hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline
 from hy3dgen.texgen import Hunyuan3DPaintPipeline
 
-model_path = 'tencent/Hunyuan3D-2'
+model_path = './Hunyuan3D-2'  # Changed to local path
 pipeline_shapegen = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(model_path)
 pipeline_texgen = Hunyuan3DPaintPipeline.from_pretrained(model_path)
 


### PR DESCRIPTION
- Modified `hy3dgen.shapegen.utils.smart_load_model` to prioritize loading models from a direct local path if it exists, before checking the cache or Hugging Face Hub.
- Updated `minimal_demo.py` to use './Hunyuan3D-2' as the model path, enabling it to run with locally downloaded checkpoints in that directory structure.