### PR TITLE
fix: remove redundant "/" in Gradio mount path to prevent double slash in URL

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -751,5 +751,5 @@ if __name__ == '__main__':
     if args.low_vram_mode:
         torch.cuda.empty_cache()
     demo = build_app()
-    app = gr.mount_gradio_app(app, demo, path="/")
+    app = gr.mount_gradio_app(app, demo, path="")
     uvicorn.run(app, host=args.host, port=args.port, workers=1)


### PR DESCRIPTION
## Description

This PR fixes the issue where accessing the app resulted in URLs like  (double slash), which caused front-end errors.  
The fix is to set the `path` argument in `gr.mount_gradio_app` to an empty string (`""`) instead of `"/"`.  
This ensures all URLs are generated correctly with a single slash.

---

## Code Diff

````python
# ...existing code...
-    app = gr.mount_gradio_app(app, demo, path="/")
+    app = gr.mount_gradio_app(app, demo, path="")
# ...existing code...
````

---

After merging this PR, the app will no longer generate URLs with double slashes, and the front-end will work as expected.