### PR TITLE
custom_rasterizer path fix

### DIFF
--- a/hy3dgen/texgen/differentiable_renderer/mesh_render.py
+++ b/hy3dgen/texgen/differentiable_renderer/mesh_render.py
@@ -142,7 +142,7 @@ class MeshRender():
 
         self.raster_mode = raster_mode
         if self.raster_mode == 'cr':
-            import custom_rasterizer as cr
+            import hy3dgen.texgen.custom_rasterizer as cr
             self.raster = cr
         else:
             raise f'No raster named {self.raster_mode}'


### PR DESCRIPTION
The sample code seems to throw `ModuleNotFoundError: No module named 'custom_rasterizer'
` for me. I modified the path on the `mesh_render.py` in order to fix this. Now it does not throw that error anymore, but I do get  `torch.cuda.OutOfMemoryError` on a 12GB VRAM GPU so I can't confirm if this is enough for solve the issue