### PR TITLE
Allow the users to use image file path as input for api_server.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,9 @@ python api_server.py --host 0.0.0.0 --port 8080
 A demo post request for image to 3D without texture.
 
 ```bash
-img_b64_str=$(base64 -i assets/demo.png)
 curl -X POST "http://localhost:8080/generate" \
      -H "Content-Type: application/json" \
-     -d '{
-           "image": "'"$img_b64_str"'",
-         }' \
+     -d '{ "image_file": "assets/demo.png" }' \
      -o test2.glb
 ```
 

--- a/api_server.py
+++ b/api_server.py
@@ -188,6 +188,9 @@ class ModelWorker:
         if 'image' in params:
             image = params["image"]
             image = load_image_from_base64(image)
+        elif 'image_file' in params:
+            image_file = params["image_file"]
+            image = Image.open(image_file)
         else:
             if 'text' in params:
                 text = params["text"]


### PR DESCRIPTION
When the users are using curl to pass image base64 data, they may get trouble with `bash: /usr/bin/curl: Argument list too long`. This update allows the user to use image_file path as input.