### PR TITLE
fix --model_path argument in api_server.py

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -303,6 +303,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8081)
     parser.add_argument("--model_path", type=str, default='tencent/Hunyuan3D-2mini')
     parser.add_argument("--tex_model_path", type=str, default='tencent/Hunyuan3D-2')
+    parser.add_argument('--subfolder', type=str, default="hunyuan3d-dit-v2-mini-turbo")
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--limit-model-concurrency", type=int, default=5)
     parser.add_argument('--enable_tex', action='store_true')
@@ -312,5 +313,5 @@ if __name__ == "__main__":
     model_semaphore = asyncio.Semaphore(args.limit_model_concurrency)
 
     worker = ModelWorker(model_path=args.model_path, device=args.device, enable_tex=args.enable_tex,
-                         tex_model_path=args.tex_model_path)
+                         tex_model_path=args.tex_model_path, subfolder=args.subfolder)
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
If you pass a `--model_path` to `api_server.py` that you haven't downloaded already, it won't be able to resolve because the subfolder in `api_server.py` doesn't exist:
`subfolder='hunyuan3d-dit-v2-mini-turbo'`

https://huggingface.co/tencent/Hunyuan3D-2/tree/main

there's currently no way to pass a subfolder to `api_server.py` via args.
After the change you can call

```diff
    python3 api_server.py \
        --host 0.0.0.0 \
        --port 8080 \
        --enable_tex \
        --model_path tencent/Hunyuan3D-2 \
+       --subfolder hunyuan3d-dit-v2-0-turbo \
        --tex_model_path tencent/Hunyuan3D-2
```

as you can see I changed subfolder from `hunyuan3d-dit-v2-mini-turbo` to `hunyuan3d-dit-v2-0-turbo`