### PR TITLE
feat: add standalone launchers and fix model path resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ gradio_cache/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+models/

--- a/hy3dgen/shapegen/utils.py
+++ b/hy3dgen/shapegen/utils.py
@@ -94,8 +94,8 @@ def smart_load_model(
 ):
     original_model_path = model_path
     # try local path
-    base_dir = os.environ.get('HY3DGEN_MODELS', '~/.cache/hy3dgen')
-    model_path = os.path.expanduser(os.path.join(base_dir, model_path, subfolder))
+    base_dir = os.path.expanduser(os.environ.get('HY3DGEN_MODELS', '~/.cache/hy3dgen'))
+    model_path = os.path.normpath(os.path.join(base_dir, model_path, subfolder))
     logger.info(f'Try to load model from local path: {model_path}')
     if not os.path.exists(model_path):
         logger.info('Model path not exists, try to download from huggingface')

--- a/run_hy3d.bat
+++ b/run_hy3d.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Hunyuan3D launcher - strips PYTHONPATH and uses correct Python venv
+setlocal
+
+REM Hardcode our CUDA PyTorch venv python (bypasses uv/system python)
+set "PY=%~dp0.venv\Scripts\python.exe"
+
+REM Clear PYTHONPATH so Hermes packages don't shadow our venv
+set PYTHONPATH=
+set PYTHONHOME=
+
+REM Set model cache location
+set HF_HOME=G:\Hunyuan3D-2-Standalone\models
+
+echo Running Hunyuan3D with: %PY%
+"%PY%" "%~dp0run_hy3d.py" %*
+
+endlocal

--- a/run_hy3d.py
+++ b/run_hy3d.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Bootstrap launcher — cleans sys.path to avoid Hermes PYTHONPATH pollution.
+Usage: python run_hy3d.py --image_path YOUR_IMAGE.jpg [--output OUTPUT.glb]"""
+
+import os, sys, argparse
+
+# ── Bootstrap: remove Hermes paths from sys.path before any imports ──
+hermes_markers = ['hermes-agent', 'hermes_workspace']
+cleaned = []
+for p in list(sys.path):
+    if any(marker in p.lower() for marker in hermes_markers):
+        cleaned.append(p)
+sys.path[:] = [p for p in sys.path if p not in cleaned]
+
+os.environ.pop('PYTHONPATH', None)
+os.environ.setdefault('HF_HOME', 'G:/Hunyuan3D-2-Standalone/models')
+
+# Now safe to import everything
+from PIL import Image
+import torch
+print(f"PyTorch {torch.__version__} | CUDA: {torch.cuda.is_available()}")
+
+from hy3dgen.rembg import BackgroundRemover
+from hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image_path', required=True, help='Input image')
+    parser.add_argument('--output', default=None, help='Output .glb file path')
+    args = parser.parse_args()
+
+    # Load pipeline
+    print("Loading Hunyuan3D model...")
+    pipeline_shapegen = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(
+        "tencent/Hunyuan3D-2", subfolder="hunyuan3d-dit-v2-0"
+    )
+    
+    # Background removal
+    print("Removing background...")
+    bg_remover = BackgroundRemover()
+    input_image_path = args.image_path
+    if not os.path.exists(input_image_path):
+        print(f"ERROR: Image not found at {input_image_path}")
+        sys.exit(1)
+    
+    image_pil = Image.open(input_image_path).convert("RGB")
+    image_masked = bg_remover(image_pil)
+    
+    # Generate 3D shape
+    print("Generating 3D mesh (this takes ~2-5 minutes)...")
+    meshes_list = pipeline_shapegen(
+        image=image_masked,
+        num_inference_steps=30,
+        mc_algo="mc",
+    )
+    
+    output_path = args.output or "output.glb"
+    from trimesh.exchange import glb
+    mesh_obj = meshes_list[0]
+    with open(output_path, "wb") as f:
+        f.write(glb.export_glb(mesh_obj))
+    
+    print(f"✓ Done! Output saved to: {output_path}")
+
+if __name__ == "__main__":
+    main()

--- a/run_hy3d_web.bat
+++ b/run_hy3d_web.bat
@@ -1,0 +1,25 @@
+@echo off
+REM Hunyuan3D-2.1 Gradio Web UI launcher (local-only, no HF downloads)
+setlocal
+
+set "PY=%~dp0.venv\Scripts\python.exe"
+set PYTHONPATH=
+set PYTHONHOME=
+
+:: Point hy3dgen to our local model cache root
+set HY3DGEN_MODELS=G:\hf_cache
+set HF_HOME=G:\hf_cache
+set TRANSFORMERS_CACHE=G:\hf_cache
+
+:: Force offline mode to prevent any HuggingFace downloads
+set HF_HUB_OFFLINE=1
+
+echo Starting Hunyuan3D-2.1 Web UI at http://localhost:7860 ...
+"%PY%" "%~dp0gradio_app.py" ^
+    --port 7860 ^
+    --low_vram_mode ^
+    --model_path "G:\hf_cache\models--tencent--Hunyuan3D-2\snapshots\9cd649ba6913f7a852e3286bad86bfa9a2d83dcf" ^
+    --subfolder "hunyuan3d-dit-v2-0" ^
+    --texgen_model_path "G:\hf_cache\models--tencent--Hunyuan3D-2\snapshots\9cd649ba6913f7a852e3286bad86bfa9a2d83dcf"
+
+endlocal


### PR DESCRIPTION
- Add run_hy3d.py bootstrap launcher that strips Hermes PYTHONPATH pollution before importing hy3dgen modules
- Add run_hy3d.bat Windows CLI wrapper (venv python, clean env)
- Add run_hy3d_web.bat Gradio web UI launcher with offline mode
- Fix smart_load_model: expanduser now applies to base_dir only (was incorrectly wrapping the joined path), added normpath for consistent Windows path handling
- Ignore models/ directory in git to exclude multi-GB cache